### PR TITLE
broken mV2adc

### DIFF
--- a/picosdk/functions.py
+++ b/picosdk/functions.py
@@ -24,7 +24,7 @@ def adc2mV(bufferADC, range, maxADC):
 
     return bufferV
 
-def mV2adc(volts, range, maxADC):
+def mV2adc(millivolts, range, maxADC):
     """
         mV2adc(
                 float                   millivolts


### PR DESCRIPTION
value is passed with name volts, but internally millivolts is used

Fixes #.

Changes proposed in this pull request:

*
*
*
