### PR TITLE
fix a bug in mV2adc()

### DIFF
--- a/picosdk/functions.py
+++ b/picosdk/functions.py
@@ -24,7 +24,7 @@ def adc2mV(bufferADC, range, maxADC):
 
     return bufferV
 
-def mV2adc(volts, range, maxADC):
+def mV2adc(millivolts, range, maxADC):
     """
         mV2adc(
                 float                   millivolts


### PR DESCRIPTION
the function takes "volts" but then attempts to use "millivolts" in the function's body.

this breaks at least the `ps5000aBlockExample.py`, line 73

Fixes #.

Changes proposed in this pull request:

* update mV2adc() to take in "millivolts" rather than volts
*
*
