### PR TITLE
Bugfix in ps6000RapidBlockExample.py - TimeUnits must be array

### DIFF
--- a/ps6000Examples/ps6000RapidBlockExample.py
+++ b/ps6000Examples/ps6000RapidBlockExample.py
@@ -269,7 +269,7 @@ assert_pico_ok(status["GetValuesBulk"])
 # Fromsegmentindex = 0
 # Tosegementindex = 9
 Times = (ctypes.c_int16*10)()
-TimeUnits = ctypes.c_char()
+TimeUnits = (ctypes.c_int16*10)()
 status["GetValuesTriggerTimeOffsetBulk"] = ps.ps6000GetValuesTriggerTimeOffsetBulk64(chandle, ctypes.byref(Times), ctypes.byref(TimeUnits), 0, 9)
 assert_pico_ok(status["GetValuesTriggerTimeOffsetBulk"])
 


### PR DESCRIPTION
Fixes #.
The function `ps6000GetValuesTriggerTimeOffsetBulk64` takes, according to the specification/programming manual 

> timeUnits, an array of integers. The array must be long enough to hold the number of requested times [...]

However, it was not an array in the `ps6000RapidBlockExample.py`, line 272. If you do not fix this, you get a segfault.

Changes proposed in this pull request:

* change datatype of TimeUnits to (ctypes.c_int16*10)() instead of  ctypes.c_char()
