### PR TITLE
Hardcode location of C libraries on OS X

### DIFF
--- a/picosdk/library.py
+++ b/picosdk/library.py
@@ -10,6 +10,7 @@ this type and attach the missing methods.
 from __future__ import print_function
 
 import sys
+import os
 from ctypes import c_int16, c_int32, c_uint32, c_float, create_string_buffer, byref
 from ctypes.util import find_library
 import collections
@@ -65,6 +66,11 @@ class Library(object):
 
     def _load(self):
         library_path = find_library(self.name)
+
+        if sys.platform == 'darwin':
+            library_path = f"/Applications/PicoScope 6.app/Contents/Resources/lib/lib{self.name}.dylib"
+            if not os.path.exists(library_path):
+                raise CannotFindPicoSDKError("PicoScope is not installed or cannot be found.")
 
         if library_path is None:
             env_var_name = "PATH" if sys.platform == 'win32' else "LD_LIBRARY_PATH"


### PR DESCRIPTION
Changes proposed in this pull request:

I have hardcoded the path to the C libraries on OS X because `find_library` + LD_LIBRARY_PATH is not working. Hardcoding is in line with the official recommendations:

> If wrapping a shared library with ctypes, it may be better to determine the shared library name at development time, and hardcode that into the wrapper module instead of using find_library() to locate the library at runtime. ([source](https://docs.python.org/3/library/ctypes.html#ctypes-reference))

I have tested this on OS X Mojave (10.14.6), and it works as expected.