### PR TITLE
add missing ps6000.BlockReadyType

### DIFF
--- a/picosdk/ps6000.py
+++ b/picosdk/ps6000.py
@@ -637,6 +637,18 @@ doc = """ PICO_STATUS ps6000RunStreaming
 ps6000.make_symbol("_RunStreaming", "ps6000RunStreaming", c_uint32,
                    [c_int16, c_void_p, c_int32, c_uint32, c_uint32, c_int16, c_uint32, c_int32, c_uint32], doc)
 				   
+doc = """ void ps6000BlockReady
+    (
+        int16_t          handle,
+        PICO_STATUS      status,
+        void             *pParameter
+    ); """
+ps6000.BlockReadyType = C_CALLBACK_FUNCTION_FACTORY(None,
+                                                    c_int16,
+                                                    c_uint32,
+                                                    c_void_p)
+ps6000.BlockReadyType.__doc__ = doc
+
 doc = """ void ps6000StreamingReady
 	(
 		int16_t				handle,


### PR DESCRIPTION
Changes proposed in this pull request:

* Add missing Python wrapper for ps6000BlockReady

Tested with a PicoScope 6404D. We were unable to test passing parameters via pParameter because we could not find the wrapper for the C void pointer.
