### PR TITLE
Update ps5000aRapidBlockExample.py

### DIFF
--- a/ps5000aExamples/ps5000aRapidBlockExample.py
+++ b/ps5000aExamples/ps5000aRapidBlockExample.py
@@ -78,7 +78,7 @@ timebase = 2
 # MaxSamples = ctypes.byref(returnedMaxSamples)
 # Segement index = 0
 timeIntervalns = ctypes.c_float()
-returnedMaxSamples = ctypes.c_int16()
+returnedMaxSamples = ctypes.c_int32()
 status["GetTimebase"] = ps.ps5000aGetTimebase2(chandle, timebase, maxsamples, ctypes.byref(timeIntervalns), ctypes.byref(returnedMaxSamples), 0)
 assert_pico_ok(status["GetTimebase"])
 
@@ -286,7 +286,7 @@ assert_pico_ok(status["GetValuesBulk"])
 # Timeunits = TimeUnits = ctypes.c_char() = ctypes.byref(TimeUnits)
 # Fromsegmentindex = 0
 # Tosegementindex = 9
-Times = (ctypes.c_int16*10)()
+Times = (ctypes.c_int64*10)()
 TimeUnits = ctypes.c_char()
 status["GetValuesTriggerTimeOffsetBulk"] = ps.ps5000aGetValuesTriggerTimeOffsetBulk64(chandle, ctypes.byref(Times), ctypes.byref(TimeUnits), 0, 9)
 assert_pico_ok(status["GetValuesTriggerTimeOffsetBulk"])


### PR DESCRIPTION
This example program will randomly crash with access violations (0xC0000005). Have traced this to ctypes.byref() passing pointers with incorrect memory sizes on the indicated lines:
* 81-82 GetTimeBase2 expects returnedMaxSamples as * int32_t, was receiving byref(int16).
* 290-292 GetValuesTimeOffsetBulk64 expects Times as * int64_t, was receiving byref(int16).
