### PR TITLE
Fix library load on Linux: try lower-case library name

### DIFF
--- a/picosdk/library.py
+++ b/picosdk/library.py
@@ -67,6 +67,9 @@ class Library(object):
         library_path = find_library(self.name)
 
         if library_path is None:
+            library_path = find_library(self.name.lower())
+
+        if library_path is None:
             env_var_name = "PATH" if sys.platform == 'win32' else "LD_LIBRARY_PATH"
             raise CannotFindPicoSDKError("PicoSDK (%s) not found, check %s" % (self.name, env_var_name))
 


### PR DESCRIPTION
Fixes issue when loading `"usbPt104"` library which on Linux is effectively `/opt/picoscope/lib/libusbpt104.so.2`; `ctypes.util .find_library("usbPt104")` returns `None`, whereas `ctypes.util .find_library("usbpt104")` works.

Changes proposed in this pull request:

* after unsuccessful library load attempt simply try again but with a lower-case name
