### PR TITLE
Update timeaxis in ps2000aBlockexample.py.

### DIFF
--- a/ps2000aExamples/ps2000aBlockExample.py
+++ b/ps2000aExamples/ps2000aBlockExample.py
@@ -173,7 +173,8 @@ adc2mVChAMax =  adc2mV(bufferAMax, chARange, maxADC)
 adc2mVChBMax =  adc2mV(bufferBMax, chBRange, maxADC)
 
 # Create time data
-time = np.linspace(0, (cTotalSamples.value) * timeIntervalns.value, cTotalSamples.value)
+# Last point in time is at (n-1)*deltat for n being the total number of samples, not at n.
+time = np.linspace(0, (cTotalSamples.value-1) * timeIntervalns.value, cTotalSamples.value)
 
 # plot data from channel A and B
 plt.plot(time, adc2mVChAMax[:])


### PR DESCRIPTION
If collecting `n` samples with a time delta of `deltat`, then a time axis starting at 0 should end at `(n-1)*deltat`, not at `n*deltat`. 
I corrected this in this example, but this issue may persist throughout other examples and models as well.

Fixes #.

Changes proposed in this pull request:

* I corrected the time axis in the ps2000aBlockExample.py
* I suggest to change all examples, that create the time axis via `np.linspace()`, in a similar way
* I suggest also to adjust the time axis, such that `t=0` is synchronized with the trigger.

Code example:
```python
import numpy as np

preTriggerSamples = 250
postTriggerSamples = 750
totalSamples = preTriggerSamples + postTriggerSamples

# For a time axis starting at t=0
time = np.linspace(0, totalSamples-1, totalSamples)*timedelta
# or for a time axis with t=0 synchronized to the trigger
time = np.linspace(-preTriggerSamples, postTriggerSamples-1, totalSamples)*timedelta
# Here, timedelta is the timebase in ns.
```
Note the `-1` in the second argument (stop value) of the call to `np.linspace(start, stop, num)`.
