### PR TITLE
Fix: Added parentheses to print commands

### DIFF
--- a/ps3000aExamples/ps3000aBlockMSOExample.py
+++ b/ps3000aExamples/ps3000aBlockMSOExample.py
@@ -98,7 +98,7 @@ status["SetDataBuffers"] = ps.ps3000aSetDataBuffers(chandle,
                                                     0)
 assert_pico_ok(status["SetDataBuffers"])
 
-print "Starting data collection..."
+print ("Starting data collection...")
 
 # Starts the block capture
 # handle = chandle
@@ -143,7 +143,7 @@ while ready.value == check.value:
 status["GetValues"] = ps.ps3000aGetValues(chandle, 0, ctypes.byref(cTotalSamples), 1, 0, 0, ctypes.byref(overflow))
 assert_pico_ok(status["GetValues"])
 
-print "Data collection complete."
+print ("Data collection complete.")
 
 # Obtain binary for Digital Port 0
 # The tuple returned contains the channels in order (D7, D6, D5, ... D0).
@@ -154,7 +154,7 @@ time = np.linspace(0, (cTotalSamples.value - 1) * timeIntervalNs.value, cTotalSa
 
 # Plot the data from digital channels onto a graph
 
-print "Plotting data..."
+print ("Plotting data...")
 
 plt.figure(num='PicoScope 3000 Series (A API) MSO Block Capture Example')
 plt.title('Plot of Digital Port 0 digital channels vs. time')
@@ -171,7 +171,7 @@ plt.ylabel('Logic Level')
 plt.legend(loc="upper right")
 plt.show()
 
-print "Close figure to stop the device and close the connection."
+print ("Close figure to stop the device and close the connection.")
 
 # Stops the scope
 # handle = chandle


### PR DESCRIPTION
Fixes missing parentheses for print commands in ps3000aExamples/ps3000aBlockMSOExamplex.py.
