### PR TITLE
Update ps6000aBlockAdvancedTriggerExample.py

### DIFF
--- a/ps6000aExamples/ps6000aBlockAdvancedTriggerExample.py
+++ b/ps6000aExamples/ps6000aBlockAdvancedTriggerExample.py
@@ -71,8 +71,8 @@ status["setTriggerChannelDirections"] = ps.ps6000aSetTriggerChannelDirections(ch
 assert_pico_ok(status["setTriggerChannelDirections"])
 
 channelProperties = (struct.PICO_TRIGGER_CHANNEL_PROPERTIES * 2)()
-channelProperties[0] = struct.PICO_TRIGGER_CHANNEL_PROPERTIES(mV2adc(1000,channelRange,maxADC), 0, 0, 0, channelA)
-channelProperties[1] = struct.PICO_TRIGGER_CHANNEL_PROPERTIES(mV2adc(1000,channelRange,maxADC), 0, 0, 0, channelB)
+channelProperties[0] = struct.PICO_TRIGGER_CHANNEL_PROPERTIES(int(mV2adc(1000,channelRange,maxADC)), 0, 0, 0, channelA)
+channelProperties[1] = struct.PICO_TRIGGER_CHANNEL_PROPERTIES(int(mV2adc(1000,channelRange,maxADC)), 0, 0, 0, channelB)
 nChannelProperties = 2
 autoTriggerMicroSeconds = 1000000
 status["setTriggerChannelProperties"] = ps.ps6000aSetTriggerChannelProperties(chandle, ctypes.byref(channelProperties),nChannelProperties,0,autoTriggerMicroSeconds)


### PR DESCRIPTION
Function round() which is used in functions.mV2adc(), will return float value in python2.7 but return int value in python3.x.  this will cause the script crash, so a convertion is added.

Fixes #

Changes proposed in this pull request:

*add convertion for the data type of func mV2adc, from float to int, in python2.7
*
