### PR TITLE
Update COMMUNICATION_TYPE  in usbPT104.py

### DIFF
--- a/picosdk/usbPT104.py
+++ b/picosdk/usbPT104.py
@@ -55,7 +55,7 @@ def _define_communication_type():
     
     return {k.upper(): v for k, v in locals().items() if k.startswith("CT")}
     
-usbPt104.COMMUNICATION_TYPE = _define_communication_type
+usbPt104.COMMUNICATION_TYPE = _define_communication_type()
 
 doc = """ PICO_STATUS UsbPt104CloseUnit
     (


### PR DESCRIPTION
Missing parentheses in called function _define_communication_type in the definition of COMMUNICATION_TYPE

Fixes #.

Changes proposed in this pull request:

*
*
*
