### PR TITLE
Add files and directories to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,13 @@
 # All platforms
 
 **/*.h
+
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+
+# Distribution / packaging
+build/
+dist/
+*.egg-info/
+*.egg


### PR DESCRIPTION
Quite a few files and directories showed up in GitHub after installing the package. It would be great to add them to the .gitignore file. In my case (Windows 10, Python 3.10.4) these were
* `build/`
* `dist/`
* `picosdk.egg-info/`
* `picosdk/__pycache__/`

There might be even more files/directories on other platforms, I haven't tested that yet.