### PR TITLE
ps5000BlockExample.py: fix wrong type on timeIntervalns

### DIFF
--- a/ps5000Examples/ps5000BlockExample.py
+++ b/ps5000Examples/ps5000BlockExample.py
@@ -72,7 +72,7 @@ timebase = 8
 oversample = 1
 # pointer to maxSamples = ctypes.byref(returnedMaxSamples)
 # segment index = 0
-timeIntervalns = ctypes.c_float()
+timeIntervalns = ctypes.c_long()
 returnedMaxSamples = ctypes.c_int32()
 status["getTimebase"] = ps.ps5000GetTimebase(chandle, timebase, maxSamples, ctypes.byref(timeIntervalns), oversample, ctypes.byref(returnedMaxSamples), 0)
 assert_pico_ok(status["getTimebase"])


### PR DESCRIPTION
Changes proposed in this pull request:

* Using float will not return the correct value. It returns something tiny like 1.40243665...e-45. Using c_long as the type (which is the type in the documentation) works.
