### PR TITLE
NumPy is optimized for vectorized operations, which makes it

### DIFF
--- a/picosdk/functions.py
+++ b/picosdk/functions.py
@@ -19,8 +19,10 @@ def adc2mV(bufferADC, range, maxADC):
     """
 
     channelInputRanges = [10, 20, 50, 100, 200, 500, 1000, 2000, 5000, 10000, 20000, 50000, 100000, 200000]
-    vRange = channelInputRanges[range]
-    bufferV = [(np.int64(x) * vRange) / maxADC.value for x in bufferADC]
+    # vRange = channelInputRanges[range]
+    # bufferV = [(np.int64(x) * vRange) / maxADC.value for x in bufferADC]
+    normRange = channelInputRanges[range]/maxADC.value
+    bufferV =  np.ctypeslib.as_array(bufferADC) * normRange
     
     return bufferV
 	
@@ -35,7 +37,9 @@ def adc2mVpl1000(bufferADC, range, maxADC):
 		Takes a buffer of raw adc count values and converts it into millvolts
 	"""
 	
-	bufferV = [(x * range) / maxADC.value for x in bufferADC]
+	#bufferV = [(x * range) / maxADC.value for x in bufferADC]
+	normRange = range/maxADC.value
+	bufferV =  np.ctypeslib.as_array(bufferADC) * normRange   
 	
 	return bufferV
 
@@ -196,6 +200,8 @@ def adc2mVV2(bufferADC, rangeMax, maxADC):
                
         Takes a buffer of raw adc count values and converts it into millivolts for psospa driver scopes
     """
-    buffermV = [(x * (rangeMax/1000000)) / maxADC.value for x in bufferADC]
+    #buffermV = [(x * (rangeMax/1000000)) / maxADC.value for x in bufferADC]
+    normRange = (rangeMax/1000000)/maxADC.value
+    buffermV =  np.ctypeslib.as_array(bufferADC) * normRange
     
     return buffermV


### PR DESCRIPTION
## Optimization of ADC acquisition

NumPy is optimized for vectorized operations, which makes it significantly faster than Python loops. To improve the speed of your calculation, try using NumPy directly instead of list comprehensions.

This eliminates the loop altogether, allowing NumPy to perform element-wise operations efficiently. You should see a noticeable speed improvement, especially for large arrays.

We tested these with 250 Mega points and adquisition took 96.072 s using your code
```
normRange = range/maxADC.value
bufferV =  np.ctypeslib.as_array(bufferADC) * normRange
```
by changing to:
```
bufferADC_np = np.array(bufferADC, dtype=np.int64)
bufferV = (bufferADC_np * range) / maxADC.value
```
took 1.347 s.
And if you premultiply the factor
```
normRange = range/maxADC.value
bufferV =  np.ctypeslib.as_array(bufferADC) * normRange
```
reduces to 1.022 s

Enjoy :)

Fixes #.

Changes proposed in this pull request:

* Use numpy to deal with buffers
* Use vectorial multiplication instead of for looping

