### PR TITLE
Fix setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,14 +12,18 @@ import os.path
 
 
 signalfile = ".sdkwarning"
+atleast1dll = 0
 if not os.path.exists(signalfile):
-    name = 'ps2000'
-    try:
-        if sys.platform == 'win32':
-            result = ctypes.WinDLL(find_library(name))
-        else:
-            result = cdll.LoadLibrary(find_library(name))
-    except OSError:
+    for name in ['ps2000', 'ps3000', 'ps4000', 'ps5000', 'ps2000a', 'ps3000a', 'ps4000a', 'ps5000a']:
+        try:
+            if sys.platform == 'win32':
+                result = ctypes.WinDLL(find_library(name))
+            else:
+                result = cdll.LoadLibrary(find_library(name))
+            atleast1dll = 1
+        except OSError:
+            print(f"Warning: PicoSDK installation is missing {name}.dll")
+    if not atleast1dll:
         print("Please install the PicoSDK in order to use this wrapper."
               "Visit https://www.picotech.com/downloads")
         exit(1)


### PR DESCRIPTION
# Bug fix

The setup.py file only checks for 1 .dll file out of the many available. Check for all possible .dlls instead and issue warnings if any are missing.

# Description

Either this needs to be fixed, or the option to only install models that you need when installing the PicoSDK needs to be removed. It said 'which libraries would you like to install' , so obviously I only installed the ones for the model that I had (ps4000). :) Cue several days of debugging!